### PR TITLE
Ensure mdadm conf file exists

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -157,7 +157,7 @@ galaxy_info:
   #  - all
   #  - any
   - name: EL
-  #  versions:
+    versions:
   #  - all
   #  - 5
   #  - 6

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 galaxy_info:
-  author: Larry Smith jr.
+  author: Alex Ruiz Estradera
   description: An [Ansible] role to install and manage [mdadm] raid arrays.
   # company: your company (optional)
 
@@ -156,12 +156,12 @@ galaxy_info:
   #  versions:
   #  - all
   #  - any
-  #- name: EL
+  - name: EL
   #  versions:
   #  - all
   #  - 5
   #  - 6
-  #  - 7
+    - 7
   #- name: Windows
   #  versions:
   #  - all

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -95,6 +95,11 @@
         array_check.results[0].rc == 0 and
         array_removed.changed
 
+- name: arrays | Ensure /etc/mdadm/ directory exists
+  file:
+    path: /etc/mdadm/
+    state: directory
+
 # Updating /etc/mdadm/mdadm.conf in order to persist between reboots
 - name: arrays | Updating /etc/mdadm/mdadm.conf
   lineinfile:

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -119,4 +119,15 @@
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
   command: "update-initramfs -u"
-  when: array_removed.changed
+  when: array_removed.changed and ansible_os_family == "Debian"
+
+# Updates initramfs archives in /boot
+- name: arrays | Updating Initramfs
+  command: "mv /boot/initramfs-$(uname -r).img /boot/initramfs-$(uname -r)-backup.img"
+  when: array_removed.changed and ansible_os_family == "RedHat"
+
+# Updates initramfs archives in /boot
+- name: arrays | Updating Initramfs
+  command: "  dracut /boot/initramfs-$(uname -r).img $(uname -r)"
+  when: array_removed.changed and ansible_os_family == "RedHat"
+

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -128,6 +128,6 @@
 
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
-  command: "  dracut /boot/initramfs-$(uname -r).img $(uname -r)"
+  command: "dracut /boot/initramfs-$(uname -r).img $(uname -r)"
   when: array_removed.changed and ansible_os_family == "RedHat"
 

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -100,6 +100,12 @@
     path: /etc/mdadm/
     state: directory
 
+- name: arrays | Ensure /etc/mdadm/mdadm.conf file exists
+  copy:
+    content: ""
+    dest: /etc/mdadm/mdadm.conf
+    force: no
+
 # Updating /etc/mdadm/mdadm.conf in order to persist between reboots
 - name: arrays | Updating /etc/mdadm/mdadm.conf
   lineinfile:

--- a/tasks/el.yml
+++ b/tasks/el.yml
@@ -1,0 +1,5 @@
+---
+- name: el | Installing mdadm
+  yum:
+    name: "mdadm"
+    state: "present"


### PR DESCRIPTION
Without this PR, the file does not exist and therefore the following ansible task fails:
"arrays | Updating /etc/mdadm/mdadm.conf"