### PR TITLE
Ensure /etc/mdadm/mdadm.conf conf file exists

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -97,6 +97,11 @@
         array_check.results[0].rc == 0 and
         array_removed.changed
 
+- name: arrays | Ensure /etc/mdadm/ directory exists
+  file:
+    path: /etc/mdadm/
+    state: directory
+
 # Updating /etc/mdadm/mdadm.conf in order to persist between reboots
 - name: arrays | Updating /etc/mdadm/mdadm.conf
   lineinfile:

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -102,6 +102,12 @@
     path: /etc/mdadm/
     state: directory
 
+- name: arrays | Ensure /etc/mdadm/mdadm.conf file exists
+  copy:
+    content: ""
+    dest: /etc/mdadm/mdadm.conf
+    force: no
+
 # Updating /etc/mdadm/mdadm.conf in order to persist between reboots
 - name: arrays | Updating /etc/mdadm/mdadm.conf
   lineinfile:


### PR DESCRIPTION
Without this PR, the file does not exist and therefore the following ansible task fails:
"arrays | Updating /etc/mdadm/mdadm.conf"