### PR TITLE
Centos/RedHat: dracut is the cmd to update initramfs

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -19,7 +19,7 @@
 
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
-  command: "update-initramfs -u"
+  command: "{{ update_initramfs }}"
   when: array_created.changed
 
 # Capture the raid array details to append to /etc/mdadm/mdadm.conf
@@ -129,7 +129,7 @@
 
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
-  command: "update-initramfs -u"
+  command: "{{ update_initramfs }}"
   when: array_removed.changed and ansible_os_family == "Debian"
 
 # Updates initramfs archives in /boot

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,3 +3,7 @@
   apt:
     name: "mdadm"
     state: "present"
+
+- name: arrays | Set update_initramfs cmd to update-initramfs -u
+  set_fact:
+    update_initramfs: "update-initramfs -u"

--- a/tasks/el.yml
+++ b/tasks/el.yml
@@ -3,3 +3,7 @@
   yum:
     name: "mdadm"
     state: "present"
+
+- name: arrays | Set update_initramfs cmd to dracut -f 
+  set_fact:
+    update_initramfs: "dracut -f"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,15 @@
 ---
 # tasks file for ansible-mdadm
 #
-- include: wipe_disks.yml
-  when: >
-        mdadm_force_wipe is defined and
-        mdadm_force_wipe
 
 - include: debian.yml
   when: ansible_os_family == "Debian"
 
+- include: el.yml
+  when: ansible_os_family == "RedHat"
+
+- include: wipe_disks.yml
+  when: >
+        mdadm_force_wipe is defined and
+        mdadm_force_wipe
 - include: arrays.yml

--- a/tasks/wipe_disks.yml
+++ b/tasks/wipe_disks.yml
@@ -9,5 +9,5 @@
 
 # Updates initramfs archives in /boot
 - name: wipe_disks | Updating Initramfs
-  command: "update-initramfs -u"
+  command: "{{ update_initramfs }}"
   when: disks_wiped.changed


### PR DESCRIPTION
"update-initramfs -u" does not exist on RedHat/CentOS families.

The equivalent command is "dracut -f".