### PR TITLE
Get rid of "DEPRECATION WARNING"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,14 +2,14 @@
 # tasks file for ansible-mdadm
 #
 
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
-- include: el.yml
+- include_tasks: el.yml
   when: ansible_os_family == "RedHat"
 
-- include: wipe_disks.yml
+- include_tasks: wipe_disks.yml
   when: >
         mdadm_force_wipe is defined and
         mdadm_force_wipe
-- include: arrays.yml
+- include_tasks: arrays.yml


### PR DESCRIPTION
This should fix the following warnings:
```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature will be removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale.. This feature will be removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```