### PR TITLE
Enable setting mount options for arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ mdadm_arrays:
     mountpoint: '/mnt/md0'
     # Define if array should be present or absent
     state: 'present'
+    # Set mount options (optional)
+    opts: 'noatime'
   # - name: 'md0'
   #   devices:
   #     - '/dev/sdb'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ mdadm_arrays:
     mountpoint: '/mnt/md0'
     # Define if array should be present or absent
     state: 'present'
+    # Set mount options (optional)
+    opts: 'noatime'
   # - name: 'md0'
   #   devices:
   #     - '/dev/sdb'

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -45,6 +45,7 @@
     src: "/dev/{{ item.name }}"
     fstype: "{{ item.filesystem }}"
     state: "mounted"
+    opts: "{{ item.opts | default(omit) }}"
   with_items: '{{ mdadm_arrays }}'
   when: item.state|lower == "present"
 


### PR DESCRIPTION
Allow setting mount options via `opts` key of mdadm_array dict. If the key is present don't pass opts to the mount module.