### PR TITLE
Option to specify filesystem opts when mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ mdadm_arrays:
       - '/dev/sdc'
     # Define filesystem to partition array with
     filesystem: 'ext4'
+    filesystem_opts: ''
     # Define the array raid level
     # 0|1|4|5|6|10
     level: '1'

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -34,6 +34,7 @@
 - name: arrays | Creating Array(s) Filesystem
   filesystem:
     fstype: "{{ item.filesystem }}"
+    opts: "{{ item.filesystem_opts | default(omit) }}"
     dev: "/dev/{{ item.name }}"
   with_items: '{{ mdadm_arrays }}'
   when: item.state|lower == "present"


### PR DESCRIPTION
I am currently dealing with a special case which requires filesystem opts to format successfully, it would be nice to have this as an option.