### PR TITLE
RedHat systems store mdadm.conf in /etc/mdadm.conf

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -23,7 +23,7 @@
   command: "{{ update_initramfs }}"
   when: array_created.changed
 
-# Capture the raid array details to append to /etc/mdadm/mdadm.conf
+# Capture the raid array details to append to mdadm.conf
 # in order to persist between reboots
 - name: arrays | Capturing Array Details
   command: "mdadm --detail --scan"
@@ -106,31 +106,32 @@
         array_check.results[0].rc == 0 and
         array_removed.changed
 
-- name: arrays | Ensure /etc/mdadm/ directory exists
+- name: arrays | Ensure {{ mdadm_conf }}'s directory exists
   file:
-    path: /etc/mdadm/
+    path: "{{ mdadm_conf_path }}"
     state: directory
+  when: mdadm_conf_path is defined
 
-- name: arrays | Ensure /etc/mdadm/mdadm.conf file exists
+- name: arrays | Ensure {{ mdadm_conf }} file exists
   copy:
     content: ""
-    dest: /etc/mdadm/mdadm.conf
+    dest: "{{ mdadm_conf }}"
     force: no
 
-# Updating /etc/mdadm/mdadm.conf in order to persist between reboots
-- name: arrays | Updating /etc/mdadm/mdadm.conf
+# Updating mdadm.conf in order to persist between reboots
+- name: arrays | Updating {{ mdadm_conf }}
   lineinfile:
-    dest: "/etc/mdadm/mdadm.conf"
+    dest: "{{ mdadm_conf }}"
     regexp: "^{{ item }}"
     line: "{{ item }}"
     state: "present"
   with_items: '{{ array_details.stdout_lines }}'
   when: array_created.changed
 
-# Updating /etc/mdadm/mdadm.conf in order to not persist between reboots
-- name: arrays | Updating /etc/mdadm/mdadm.conf
+# Updating mdadm.conf in order to not persist between reboots
+- name: arrays | Updating {{ mdadm_conf }}
   lineinfile:
-    dest: "/etc/mdadm/mdadm.conf"
+    dest: "{{ mdadm_conf }}"
     regexp: "^ARRAY /dev/{{ item.name }}"
     line: "ARRAY /dev/{{ item.name }}"
     state: "absent"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -4,6 +4,8 @@
     name: "mdadm"
     state: "present"
 
-- name: arrays | Set update_initramfs cmd to update-initramfs -u
+- name: arrays | Setting distribution-specific facts
   set_fact:
     update_initramfs: "update-initramfs -u"
+    mdadm_conf: "/etc/mdadm/mdadm.conf"
+    mdadm_conf_path: "/etc/mdadm"

--- a/tasks/el.yml
+++ b/tasks/el.yml
@@ -4,6 +4,7 @@
     name: "mdadm"
     state: "present"
 
-- name: arrays | Set update_initramfs cmd to dracut -f 
+- name: arrays | Setting distribution-specific facts
   set_fact:
     update_initramfs: "dracut -f"
+    mdadm_conf: "/etc/mdadm.conf"


### PR DESCRIPTION
The role incorrectly used /etc/mdadm/mdadm.conf on RedHat systems.