### PR TITLE
Fix incorrect title in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Role Name
-=========
+mrlesmithjr.mdadm
+=================
 
 An [Ansible] role to install and manage [mdadm] raid arrays.
 


### PR DESCRIPTION
Hi!

Sorry for such a trivial PR, but we recently started using a static site generator for documenting our Ansible project. It looks through all the READMEs for roles, including those from Galaxy, and unfortunately this means the mdadm role shows up as "Role Name" in our docs 😂

I set the title in the README to match the role name you get when installed from Galaxy. I wonder if you'd consider merging this?

Thanks!