### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -142,15 +142,15 @@
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
   command: "{{ update_initramfs }}"
-  when: array_removed.changed and ansible_os_family == "Debian"
+  when: array_removed.changed and ansible_facts.os_family == "Debian"
 
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
   command: "mv /boot/initramfs-$(uname -r).img /boot/initramfs-$(uname -r)-backup.img"
-  when: array_removed.changed and ansible_os_family == "RedHat"
+  when: array_removed.changed and ansible_facts.os_family == "RedHat"
 
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
   command: "dracut /boot/initramfs-$(uname -r).img $(uname -r)"
-  when: array_removed.changed and ansible_os_family == "RedHat"
+  when: array_removed.changed and ansible_facts.os_family == "RedHat"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,10 @@
 #
 
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - include_tasks: el.yml
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"
 
 - include_tasks: wipe_disks.yml
   when: >


### PR DESCRIPTION
## Description
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
