### PR TITLE
Support setting parameters when creating raid devices and use uuid for mounting

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -41,19 +41,26 @@
   - item.state|lower == "present"
   - item.filesystem is defined
 
-# Mounting raid arrays
-- name: arrays | Mounting Array(s)
-  mount:
-    name: "{{ item.mountpoint }}"
-    src: "/dev/{{ item.name }}"
-    fstype: "{{ item.filesystem }}"
-    state: "mounted"
-    opts: "{{ item.opts | default(omit) }}"
+
+# Get UUID of raid device
+- name: arrays | Get UUID of Array(s)
+  ansible.builtin.command: "lsblk /dev/{{ item.name }} -no UUID"
+  register: uuid
   with_items: '{{ mdadm_arrays }}'
   when:
   - item.state|lower == "present"
   - item.filesystem is defined
   - item.mountpoint is defined
+
+# Mounting raid arrays
+- name: arrays | Mounting Array(s)
+  mount:
+    name: "{{ item.item.mountpoint }}"
+    src: "UUID={{ item.stdout_lines[0] }}"
+    fstype: "{{ item.item.filesystem }}"
+    state: "mounted"
+    opts: "{{ item.item.opts | default(omit) }}"
+  loop: '{{ uuid.results }}'
 
 # Unmounting raid arrays in preparation of destroying
 - name: arrays | Unmounting Array(s)

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -11,7 +11,7 @@
 # Creating raid arrays
 # We pass yes in order to accept any questions prompted for yes|no
 - name: arrays | Creating Array(s)
-  shell: "yes | mdadm --create /dev/{{ item.name }} --level={{ item.level }} --raid-devices={{ item.devices|count }} {{ item.devices| join (' ') }}"
+  shell: "yes | mdadm --create /dev/{{ item.name }} --level={{ item.level }}  {{ item.mdadm_options | default('') }} --raid-devices={{ item.devices|count }} {{ item.devices| join (' ') }}"
   register: "array_created"
   with_items: '{{ mdadm_arrays }}'
   when: >


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
1. I need to change the chunk size  of the mdadm device. When this change, this can be done by writing:
```
mdadm_options: '--chunk=64K'
```

2. I prefer mounting devices using UUID and not name.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
