### PR TITLE
fix(mdadm): name not posix compatible

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -11,7 +11,7 @@
 # Creating raid arrays
 # We pass yes in order to accept any questions prompted for yes|no
 - name: arrays | Creating Array(s)
-  shell: "yes | mdadm --create /dev/{{ item.name }} --level={{ item.level }} {% if item.level != 1 %}--chunk={{item.chunk_size|default('512K')}}{% endif %} --metadata={{ item.raid_metadata_version | default(1.2) }} --raid-devices={{ item.devices|count }} {{ item.devices| join (' ') }}"
+  shell: "yes | mdadm --create {{ item.name }} --name={{ item.name }} --level={{ item.level }} {% if item.level != 1 %}--chunk={{item.chunk_size|default('512K')}}{% endif %} --metadata={{ item.raid_metadata_version | default(1.2) }} --raid-devices={{ item.devices|count }} {{ item.devices| join (' ') }}"
   register: "array_created"
   with_items: '{{ mdadm_arrays }}'
   when: >


### PR DESCRIPTION
# 🔧 Fix `mdadm` Compatibility on Ubuntu 24.04 (mdadm 4.3)

## 📖 Description

### **Why this PR?**

With the release of **Ubuntu 24.04**, the **mdadm 4.3** version introduced stricter **POSIX-compliant naming rules**, causing RAID array creation to fail when using a `/dev/` prefixed name.

#### **Observed Issue:**

On Ubuntu 24.04, running:
```sh
mdadm --create /dev/md200 --level=5 --chunk=512K --metadata=1.2 --raid-devices=4 /dev/nvme0n1 /dev/nvme1n1 /dev/nvme2n1 /dev/nvme3n1
```
Fails with:
```
mdadm: Value "/dev/md200" cannot be set as devname. Reason: Not POSIX compatible.
```

#### **Fix Implemented:**
- **Removed `/dev/` prefix from RAID device name** (e.g., `md200` instead of `/dev/md200`).
- **Explicitly set `--name={{ item.name }}`** in the `mdadm` command to ensure compatibility across versions.
- **Maintains backward compatibility** with older versions (tested on Ubuntu 22.04).

---

## 🛠 Changes Made
- **Updated `tasks/arrays.yml`**

  - Changed:
  
    ```yaml
    mdadm --create /dev/{{ item.name }} ...
    ```
    to:
    
    ```yaml
    mdadm --create {{ item.name }} --name={{ item.name }} ...
    ```
- **Ensured existing Ansible tasks remain unchanged** except for name handling.

---

- Tested on:

  - ✅ **Ubuntu 22.04 (mdadm 4.2)**
  - ✅ **Ubuntu 24.04 (mdadm 4.3)**

---

## 📌 References
- **[mdadm 4.3](https://github.com/md-raid-utilities/mdadm/releases/tag/mdadm-4.3) Release Notes**: [mdadm 4.3](https://github.com/md-raid-utilities/mdadm/releases/tag/mdadm-4.3)
- **Related commit enforcing POSIX rules**:  
  - [[Commit enforcing strict name validation](https://github.com/md-raid-utilities/mdadm/commit/e2eb503bd797908f515b58428b274f1ba6a05349)](https://github.com/md-raid-utilities/mdadm/commit/e2eb503bd797908f515b58428b274f1ba6a05349)