### PR TITLE
Add auto-detection feature for RAID array creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,40 @@ None
 
 ## Example Playbook
 
+### Manual configuration
 ```yaml
 - hosts: all
   become: true
   vars:
+    mdadm_arrays:
+      - name: md200
+        devices:
+          - /dev/nvme0n1
+          - /dev/nvme1n1
+        filesystem: lvm
+        level: 5
+        state: present
   roles:
     - role: ansible-mdadm
-  tasks:
 ```
+
+### Auto-detection mode
+```yaml
+- hosts: all
+  become: true
+  vars:
+    mdadm_auto_detect_arrays: true
+    mdadm_auto_detect_config:
+      - name: md200
+        filesystem: lvm
+        level: 5
+        state: present
+        min_disks: 3
+  roles:
+    - role: ansible-mdadm
+```
+
+Note: Auto-detection will automatically use all unused disks (not mounted, not in RAID, not in LVM, not formatted) if `mdadm_arrays` is empty and `mdadm_auto_detect_arrays` is true.
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,14 @@
 #   mountpoint: '/mnt/md0'
 #   state: 'present'
 mdadm_arrays: []
+
+# Auto-detection settings
+mdadm_auto_detect_arrays: false
+mdadm_auto_detect_config:
+  # Default configuration for auto-detected arrays
+  - name: md200
+    filesystem: lvm
+    level: 5
+    state: present
+    # Minimum number of disks required for auto-detection
+    min_disks: 3

--- a/tasks/detect_unused_disks.yml
+++ b/tasks/detect_unused_disks.yml
@@ -1,0 +1,48 @@
+---
+# Detect unused disks that can be used for RAID arrays
+# This task will identify disks that are:
+# - Not mounted
+# - Not part of existing RAID arrays
+# - Not used in LVM
+# - Not formatted with a filesystem
+
+- name: detect_unused_disks | Get all block devices
+  shell: lsblk -ln -o NAME,TYPE,MOUNTPOINT,FSTYPE | grep -E '^[a-z]+[0-9]*\s+disk\s*$' | awk '{print "/dev/" $1}'
+  register: all_disks
+  changed_when: false
+
+- name: detect_unused_disks | Get mounted devices
+  shell: mount | awk '{print $1}' | grep '^/dev/' | sort | uniq
+  register: mounted_devices
+  changed_when: false
+
+- name: detect_unused_disks | Get devices used in existing RAID arrays
+  shell: cat /proc/mdstat | grep -oE 'sd[a-z]+[0-9]*|nvme[0-9]+n[0-9]+' | sed 's|^|/dev/|' | sort | uniq
+  register: raid_devices
+  changed_when: false
+  failed_when: false
+
+- name: detect_unused_disks | Get devices used in LVM
+  shell: pvs --noheadings -o pv_name 2>/dev/null | tr -d ' ' | sort | uniq
+  register: lvm_devices
+  changed_when: false
+  failed_when: false
+
+- name: detect_unused_disks | Get devices with filesystem
+  shell: blkid | cut -d: -f1 | sort | uniq
+  register: formatted_devices
+  changed_when: false
+  failed_when: false
+
+- name: detect_unused_disks | Filter unused disks
+  set_fact:
+    unused_disks: "{{ all_disks.stdout_lines | 
+      difference(mounted_devices.stdout_lines | default([])) |
+      difference(raid_devices.stdout_lines | default([])) |
+      difference(lvm_devices.stdout_lines | default([])) |
+      difference(formatted_devices.stdout_lines | default([])) }}"
+
+- name: detect_unused_disks | Debug unused disks found
+  debug:
+    msg: "Unused disks detected: {{ unused_disks }}"
+  when: unused_disks | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,4 +12,18 @@
   when: >
         mdadm_force_wipe is defined and
         mdadm_force_wipe
+
+- include_tasks: detect_unused_disks.yml
+  when: >
+        mdadm_auto_detect_arrays and
+        (mdadm_arrays | length == 0)
+
+- name: main | Set auto-detected arrays
+  set_fact:
+    mdadm_arrays: "{{ mdadm_auto_detect_config | map('combine', {'devices': unused_disks}) | list }}"
+  when: >
+        mdadm_auto_detect_arrays and
+        (mdadm_arrays | length == 0) and
+        (unused_disks | length >= mdadm_auto_detect_config[0].min_disks)
+
 - include_tasks: arrays.yml


### PR DESCRIPTION
## Summary
- Introduces automatic detection of unused disks for RAID array creation
- Adds new task `detect_unused_disks.yml` to identify available storage devices
- Updates configuration with auto-detection settings and examples
- Provides both manual and automatic configuration modes

## Changes
- **New file**: `tasks/detect_unused_disks.yml` - Core auto-detection logic
- **Modified**: `tasks/main.yml` - Integration of auto-detection workflow
- **Modified**: `defaults/main.yml` - Auto-detection configuration options
- **Modified**: `README.md` - Updated documentation with usage examples

## Features
- Detects disks not mounted, not in RAID, not in LVM, and not formatted
- Configurable minimum disk requirements
- Fallback to manual configuration if auto-detection fails
- Debug output for detected unused disks

## Test plan
- [ ] Test auto-detection on systems with unused disks
- [ ] Verify manual configuration still works
- [ ] Test minimum disk requirement enforcement
- [ ] Validate that used disks are properly excluded

🤖 Generated with [Claude Code](https://claude.ai/code)