### PR TITLE
Integrate auto-detection into mdadm_arrays configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,40 @@ None
 
 ## Example Playbook
 
+### Manual configuration
 ```yaml
 - hosts: all
   become: true
   vars:
+    mdadm_arrays:
+      - name: md200
+        devices:
+          - /dev/nvme0n1
+          - /dev/nvme1n1
+        filesystem: lvm
+        level: 5
+        state: present
   roles:
     - role: ansible-mdadm
-  tasks:
 ```
+
+### Auto-detection mode
+```yaml
+- hosts: all
+  become: true
+  vars:
+    mdadm_auto_detect_arrays: true
+    mdadm_auto_detect_config:
+      - name: md200
+        filesystem: lvm
+        level: 5
+        state: present
+        min_disks: 3
+  roles:
+    - role: ansible-mdadm
+```
+
+Note: Auto-detection will automatically use all unused disks (not mounted, not in RAID, not in LVM, not formatted) if `mdadm_arrays` is empty and `mdadm_auto_detect_arrays` is true.
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,14 @@
 #   mountpoint: '/mnt/md0'
 #   state: 'present'
 mdadm_arrays: []
+
+# Auto-detection settings
+mdadm_auto_detect_arrays: false
+mdadm_auto_detect_config:
+  # Default configuration for auto-detected arrays
+  - name: md200
+    filesystem: lvm
+    level: 5
+    state: present
+    # Minimum number of disks required for auto-detection
+    min_disks: 3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,10 @@
 #   state: 'present'
 #   # Set mount options (optional)
 #   opts: 'noatime'
+#   # Auto-detect unused disks (optional, default false)
+#   # If true and devices is empty, automatically detect unused disks
+#   # If true and devices is defined, will trigger an error
+#   auto_detect: false
 #
 # Example RAID5:
 # mdadm_arrays:
@@ -34,15 +38,15 @@
 #   level: '5'
 #   mountpoint: '/mnt/md0'
 #   state: 'present'
+#   auto_detect: false
+#
+# Example auto-detect RAID5:
+# mdadm_arrays:
+# - name: 'md200'
+#   devices: []
+#   filesystem: 'lvm'
+#   level: '5'
+#   state: 'present'
+#   auto_detect: true
+#   min_disks: 3  # Minimum number of disks required for auto-detection
 mdadm_arrays: []
-
-# Auto-detection settings
-mdadm_auto_detect_arrays: false
-mdadm_auto_detect_config:
-  # Default configuration for auto-detected arrays
-  - name: md200
-    filesystem: lvm
-    level: 5
-    state: present
-    # Minimum number of disks required for auto-detection
-    min_disks: 3

--- a/tasks/detect_unused_disks.yml
+++ b/tasks/detect_unused_disks.yml
@@ -1,0 +1,48 @@
+---
+# Detect unused disks that can be used for RAID arrays
+# This task will identify disks that are:
+# - Not mounted
+# - Not part of existing RAID arrays
+# - Not used in LVM
+# - Not formatted with a filesystem
+
+- name: detect_unused_disks | Get all block devices
+  shell: lsblk -ln -o NAME,TYPE,MOUNTPOINT,FSTYPE | grep -E '^[a-z]+[0-9]*\s+disk\s*$' | awk '{print "/dev/" $1}'
+  register: all_disks
+  changed_when: false
+
+- name: detect_unused_disks | Get mounted devices
+  shell: mount | awk '{print $1}' | grep '^/dev/' | sort | uniq
+  register: mounted_devices
+  changed_when: false
+
+- name: detect_unused_disks | Get devices used in existing RAID arrays
+  shell: cat /proc/mdstat | grep -oE 'sd[a-z]+[0-9]*|nvme[0-9]+n[0-9]+' | sed 's|^|/dev/|' | sort | uniq
+  register: raid_devices
+  changed_when: false
+  failed_when: false
+
+- name: detect_unused_disks | Get devices used in LVM
+  shell: pvs --noheadings -o pv_name 2>/dev/null | tr -d ' ' | sort | uniq
+  register: lvm_devices
+  changed_when: false
+  failed_when: false
+
+- name: detect_unused_disks | Get devices with filesystem
+  shell: blkid | cut -d: -f1 | sort | uniq
+  register: formatted_devices
+  changed_when: false
+  failed_when: false
+
+- name: detect_unused_disks | Filter unused disks
+  set_fact:
+    unused_disks: "{{ all_disks.stdout_lines | 
+      difference(mounted_devices.stdout_lines | default([])) |
+      difference(raid_devices.stdout_lines | default([])) |
+      difference(lvm_devices.stdout_lines | default([])) |
+      difference(formatted_devices.stdout_lines | default([])) }}"
+
+- name: detect_unused_disks | Debug unused disks found
+  debug:
+    msg: "Unused disks detected: {{ unused_disks }}"
+  when: unused_disks | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,17 +13,49 @@
         mdadm_force_wipe is defined and
         mdadm_force_wipe
 
-- include_tasks: detect_unused_disks.yml
+- name: main | Validate auto_detect configuration
+  fail:
+    msg: "Error: auto_detect is set to true but devices are also defined for array {{ item.name }}. Use either devices OR auto_detect, not both."
+  with_items: "{{ mdadm_arrays }}"
   when: >
-        mdadm_auto_detect_arrays and
-        (mdadm_arrays | length == 0)
+        item.auto_detect | default(false) and
+        item.devices is defined and
+        item.devices | length > 0
 
-- name: main | Set auto-detected arrays
-  set_fact:
-    mdadm_arrays: "{{ mdadm_auto_detect_config | map('combine', {'devices': unused_disks}) | list }}"
+- include_tasks: detect_unused_disks.yml
+  when: mdadm_arrays | selectattr('auto_detect', 'defined') | selectattr('auto_detect', 'equalto', true) | list | length > 0
+
+- name: main | Validate sufficient disks for auto-detection
+  fail:
+    msg: "Error: Not enough unused disks found for auto-detection. Found {{ unused_disks | length }} disks, but {{ item.name }} requires at least {{ item.min_disks | default(3) }} disks."
+  with_items: "{{ mdadm_arrays }}"
   when: >
-        mdadm_auto_detect_arrays and
-        (mdadm_arrays | length == 0) and
-        (unused_disks | length >= mdadm_auto_detect_config[0].min_disks)
+        item.auto_detect | default(false) and
+        (item.devices is not defined or item.devices | length == 0) and
+        unused_disks is defined and
+        unused_disks | length < item.min_disks | default(3)
+
+- name: main | Set auto-detected devices for arrays with auto_detect
+  set_fact:
+    mdadm_arrays: "{{ mdadm_arrays_updated }}"
+  vars:
+    mdadm_arrays_updated: >-
+      {%- set result = [] -%}
+      {%- for array in mdadm_arrays -%}
+        {%- if array.auto_detect | default(false) and (array.devices is not defined or array.devices | length == 0) -%}
+          {%- if unused_disks | length >= array.min_disks | default(3) -%}
+            {%- set updated_array = array | combine({'devices': unused_disks}) -%}
+            {%- set _ = result.append(updated_array) -%}
+          {%- else -%}
+            {%- set _ = result.append(array) -%}
+          {%- endif -%}
+        {%- else -%}
+          {%- set _ = result.append(array) -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ result }}
+  when: >
+        unused_disks is defined and
+        mdadm_arrays | selectattr('auto_detect', 'defined') | selectattr('auto_detect', 'equalto', true) | list | length > 0
 
 - include_tasks: arrays.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,4 +12,18 @@
   when: >
         mdadm_force_wipe is defined and
         mdadm_force_wipe
+
+- include_tasks: detect_unused_disks.yml
+  when: >
+        mdadm_auto_detect_arrays and
+        (mdadm_arrays | length == 0)
+
+- name: main | Set auto-detected arrays
+  set_fact:
+    mdadm_arrays: "{{ mdadm_auto_detect_config | map('combine', {'devices': unused_disks}) | list }}"
+  when: >
+        mdadm_auto_detect_arrays and
+        (mdadm_arrays | length == 0) and
+        (unused_disks | length >= mdadm_auto_detect_config[0].min_disks)
+
 - include_tasks: arrays.yml


### PR DESCRIPTION
## Summary
- Removes the standalone `mdadm_auto_detect_arrays` variable and integrates auto-detection functionality directly into the `mdadm_arrays` structure
- Adds `auto_detect` and `min_disks` fields to array configuration 
- Implements proper validation logic to prevent configuration conflicts

## Changes Made
- **Configuration Structure**: Added `auto_detect` boolean field and `min_disks` field to `mdadm_arrays`
- **Validation Logic**: 
  - Error if `auto_detect=true` AND `devices` are defined (conflicting configuration)
  - Error if insufficient unused disks found for auto-detection requirements
- **Auto-Detection Logic**: Only triggers when `auto_detect=true` and `devices=[]`
- **Documentation**: Updated examples showing both manual and auto-detect configurations

## Configuration Examples

### Manual RAID configuration (existing behavior):
```yaml
mdadm_arrays:
- name: 'md0'
  devices:
    - '/dev/sdb' 
    - '/dev/sdc'
  level: '1'
  filesystem: 'ext4'
  auto_detect: false  # default
```

### Auto-detect RAID configuration (new):
```yaml
mdadm_arrays:
- name: 'md200'
  devices: []  # empty for auto-detection
  level: '5'
  filesystem: 'lvm'
  auto_detect: true
  min_disks: 3
```

## Test plan
- [ ] Test manual device configuration (existing functionality)
- [ ] Test auto-detection with sufficient disks
- [ ] Test validation errors for conflicting configurations
- [ ] Test validation errors for insufficient disks
- [ ] Verify backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)