### PR TITLE
Fix Ansible Galaxy workflow deprecation warnings

### DIFF
--- a/.github/workflows/release-galaxy.yml
+++ b/.github/workflows/release-galaxy.yml
@@ -1,10 +1,7 @@
 ---
 name: Ansible Galaxy
+
 on:
-  push:
-    branches:
-      - main
-      - master
   release:
     types:
       - published
@@ -12,27 +9,21 @@ on:
 jobs:
   galaxy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          submodules: recursive
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
-          pip install pre-commit
-      - name: Trigger a new import on Galaxy.
-        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          python-version: "3.11"
+
+      - name: Install Ansible
+        run: pip install ansible-core
+
+      - name: Trigger Galaxy import
+        run: >-
+          ansible-galaxy role import
+          --api-key ${{ secrets.GALAXY_API_KEY }}
+          ${{ github.repository_owner }}
+          ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary

- Fix deprecated GitHub Actions in the Ansible Galaxy publishing workflow
- Simplify workflow and change trigger to release-only
- Update to current action versions

## Changes

- Update `actions/checkout` from v3 to v4
- Update `actions/setup-python` from v4 to v5
- Remove deprecated `actions/cache@v2` (pip caching not needed for this simple workflow)
- Update Python version from 3.9 to 3.11
- Remove unnecessary matrix strategy
- Remove installation of dev requirements and pre-commit
- Change trigger from push (main/master) to release publish only
- Simplify to install only ansible-core

## Benefits

- Eliminates deprecation warnings in GitHub Actions
- Faster workflow execution (no unnecessary dependencies)
- Cleaner publishing process (only on actual releases, not every commit)
- Uses latest stable action versions

## Configuration

The workflow requires the `GALAXY_API_KEY` secret to be configured in repository settings. If not already set:

1. Get token from https://galaxy.ansible.com/ui/token/
2. Add as repository secret at Settings > Secrets and variables > Actions