### PR TITLE
Update Python dependencies to resolve security alerts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,80 +1,70 @@
-ansible-compat==3.0.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible-core==2.13.10 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible-lint==6.8.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible==6.6.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-arrow==1.2.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-astroid==2.15.5 ; python_full_version >= "3.8.1" and python_version < "4.0"
-attrs==23.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-binaryornot==0.4.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-black==22.12.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-bracex==2.3.post1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-certifi==2023.5.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cffi==1.15.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cfgv==3.3.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-chardet==5.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-charset-normalizer==3.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-click-help-colors==0.9.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-click==8.1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-colorama==0.4.6 ; python_full_version >= "3.8.1" and python_version < "4.0" and (sys_platform == "win32" or platform_system == "Windows")
-cookiecutter==2.1.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cryptography==41.0.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-dill==0.3.6 ; python_full_version >= "3.8.1" and python_version < "4.0"
-distlib==0.3.6 ; python_full_version >= "3.8.1" and python_version < "4.0"
-distro==1.8.0 ; python_full_version >= "3.8.1" and python_version < "4.0" and (sys_platform == "linux" or sys_platform == "linux2")
-docker==6.1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-enrich==1.2.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-filelock==3.12.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-flake8==6.0.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-identify==2.5.24 ; python_full_version >= "3.8.1" and python_version < "4.0"
-idna==3.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-importlib-resources==5.12.0 ; python_full_version >= "3.8.1" and python_version < "3.9"
-isort==5.12.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jinja2-time==0.2.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jinja2==3.1.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jsonschema==4.17.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-lazy-object-proxy==1.9.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-markdown-it-py==2.2.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-markupsafe==2.1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-mccabe==0.7.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-mdurl==0.1.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-molecule-docker==2.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-molecule==4.0.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-molecule[docker]==4.0.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-mypy-extensions==1.0.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-nodeenv==1.8.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-packaging==23.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pathspec==0.11.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pkgutil-resolve-name==1.3.10 ; python_full_version >= "3.8.1" and python_version < "3.9"
-platformdirs==3.5.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pluggy==1.0.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pre-commit==2.21.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pycodestyle==2.10.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pycparser==2.21 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pyflakes==3.0.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pygments==2.15.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pylint==2.17.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pyrsistent==0.19.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-python-dateutil==2.8.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-python-slugify==8.0.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pywin32==306 ; python_full_version >= "3.8.1" and python_version < "4.0" and sys_platform == "win32"
-pyyaml==6.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-requests==2.31.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-resolvelib==0.8.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-rich==13.4.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ruamel-yaml-clib==0.2.7 ; platform_python_implementation == "CPython" and python_version < "3.12" and python_full_version >= "3.8.1"
-ruamel-yaml==0.17.31 ; python_full_version >= "3.8.1" and python_version < "4.0"
-selinux==0.2.1 ; python_full_version >= "3.8.1" and python_version < "4.0" and (sys_platform == "linux" or sys_platform == "linux2")
-setuptools==67.8.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-six==1.16.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-subprocess-tee==0.4.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-text-unidecode==1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-tomli==2.0.1 ; python_full_version >= "3.8.1" and python_full_version < "3.11.0a7"
-tomlkit==0.11.8 ; python_full_version >= "3.8.1" and python_version < "4.0"
-typing-extensions==4.6.3 ; python_full_version >= "3.8.1" and python_version < "3.11"
-urllib3==2.0.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-virtualenv==20.23.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-wcmatch==8.4.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-websocket-client==1.5.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-wrapt==1.15.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-yamllint==1.32.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-zipp==3.15.0 ; python_full_version >= "3.8.1" and python_version < "3.9"
+ansible-compat==24.5.1
+ansible-core==2.13.13
+ansible-lint==6.8.7
+arrow==1.4.0
+astroid==2.15.8
+attrs==26.1.0
+binaryornot==0.6.0
+black==22.12.0
+bracex==2.6
+certifi==2026.2.25
+cffi==2.0.0
+cfgv==3.5.0
+charset-normalizer==3.4.6
+click==8.3.1
+click-help-colors==0.9.4
+cookiecutter==2.7.1
+cryptography==46.0.5
+dill==0.4.1
+distlib==0.4.0
+docker==7.1.0
+enrich==1.2.7
+filelock==3.25.2
+flake8==6.1.0
+identify==2.6.18
+idna==3.11
+isort==5.13.2
+jinja2==3.1.6
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+lazy-object-proxy==1.12.0
+markdown-it-py==4.0.0
+markupsafe==3.0.3
+mccabe==0.7.0
+mdurl==0.1.2
+molecule==4.0.4
+molecule-docker==2.1.0
+mypy-extensions==1.1.0
+nodeenv==1.10.0
+packaging==26.0
+pathspec==1.0.4
+platformdirs==4.9.4
+pluggy==1.6.0
+pre-commit==2.21.0
+pycodestyle==2.11.1
+pycparser==3.0
+pyflakes==3.1.0
+pygments==2.19.2
+pylint==2.17.7
+python-dateutil==2.9.0.post0
+python-discovery==1.2.0
+python-slugify==8.0.4
+pyyaml==6.0.3
+referencing==0.37.0
+requests==2.33.0
+resolvelib==0.8.1
+rich==14.3.3
+rpds-py==0.30.0
+ruamel-yaml==0.17.40
+ruamel-yaml-clib==0.2.15
+six==1.17.0
+subprocess-tee==0.4.2
+text-unidecode==1.3
+tomlkit==0.14.0
+typing-extensions==4.15.0
+tzdata==2025.3
+urllib3==2.6.3
+virtualenv==21.2.0
+wcmatch==10.1
+wrapt==1.17.3
+yamllint==1.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-ansible-core==2.13.10 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible==6.6.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cffi==1.15.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cryptography==41.0.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jinja2==3.1.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-markupsafe==2.1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-packaging==23.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pycparser==2.21 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pyyaml==6.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-resolvelib==0.8.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
+ansible==6.6.0
+ansible-core==2.13.13
+cffi==2.0.0
+cryptography==46.0.5
+jinja2==3.1.6
+markupsafe==3.0.3
+packaging==26.0
+pycparser==3.0
+pyyaml==6.0.3
+resolvelib==0.8.1


### PR DESCRIPTION
## Summary
- Updates all Python dependencies to latest compatible versions
- Resolves open Dependabot security alerts (critical/high/moderate/low)

## Changes
- Regenerated pinned requirements from source files (pip-compile/Poetry)
- All dependency versions bumped to latest compatible releases

## Test Plan
- [ ] CI passes (Molecule tests)
- [ ] Verify no breaking changes in ansible-lint or molecule