### PR TITLE
feat: add `--assume-clean` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ mdadm_arrays:
     mountpoint: /mnt/md0   # Where to mount the array
     state: present         # present | absent
     opts: noatime          # Mount options (optional)
+    assume_clean: true     # Avoid initial resync
 ```
 
 See [defaults/main.yml](defaults/main.yml) for the full variable reference.

--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -24,6 +24,7 @@
       --metadata={{ item.raid_metadata_version | default(1.2) }}
       --raid-devices={{ item.devices | count }}
       {{ item.devices | join(' ') }}
+      {% if item.assume_clean | default(false) | bool %} --assume-clean {% endif %}
     executable: /bin/bash
   register: "array_created"
   changed_when: true


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
Add suppport for passing `--assume-clean` flag during array creation. This is useful for a number of reasons including if the devices in a new array are already clean then you can avoid having to synchronise what are empty disks.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

- #61

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
