### PR TITLE
feat: add `mdadm.conf` to dracut configuration

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -36,11 +36,15 @@
     item.state | lower == "present" and
     array_check.results[0].rc != 0
 
-# Updates initramfs archives in /boot
-- name: Arrays | Updating Initramfs
-  ansible.builtin.command: "{{ update_initramfs }}"
-  changed_when: true
-  when: array_created.changed
+# Ensure mdadm.conf is copied into initramfs
+- name: arrays | Configure dracut to include mdadm.conf
+  ansible.builtin.copy:
+    content: |
+      # Ensure mdadm.conf is included
+      mdadmconf="yes"
+    dest: /etc/dracut.conf.d/mdadm.conf
+    mode: 0644
+  when: array_created.changed and ansible_facts.os_family == "RedHat"
 
 # Capture the raid array details to append to mdadm.conf
 # in order to persist between reboots
@@ -163,6 +167,12 @@
   with_items: '{{ mdadm_arrays }}'
   when: >
     item.state == "absent"
+
+# Updates initramfs archives in /boot
+- name: Arrays | Updating Initramfs
+  ansible.builtin.command: "{{ update_initramfs }}"
+  changed_when: true
+  when: array_created.changed
 
 # Updates initramfs archives in /boot
 - name: Arrays | Updating Initramfs (Debian)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Ensure mdadm.conf is present within dracut configuration to ensure that array is recognised post reboot.

## Related Issue
- #63 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
