### PR TITLE
fix: rebuild initramfs after mdadm.conf is written and configure dracut on EL

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -36,12 +36,6 @@
     item.state | lower == "present" and
     array_check.results[0].rc != 0
 
-# Updates initramfs archives in /boot
-- name: Arrays | Updating Initramfs
-  ansible.builtin.command: "{{ update_initramfs }}"
-  changed_when: true
-  when: array_created.changed
-
 # Capture the raid array details to append to mdadm.conf
 # in order to persist between reboots
 - name: Arrays | Capturing Array Details
@@ -151,6 +145,14 @@
     line: "{{ item }}"
     state: "present"
   with_items: '{{ array_details.stdout_lines }}'
+  when: array_created.changed
+
+# Rebuild initramfs AFTER mdadm.conf is written so the array definitions
+# are embedded in the initramfs and the kernel can identify arrays by name
+# on the next boot (without this, arrays are renamed md127 on EL hosts).
+- name: Arrays | Updating Initramfs
+  ansible.builtin.command: "{{ update_initramfs }}"
+  changed_when: true
   when: array_created.changed
 
 # Updating mdadm.conf in order to not persist between reboots

--- a/tasks/el.yml
+++ b/tasks/el.yml
@@ -8,3 +8,10 @@
   ansible.builtin.set_fact:
     update_initramfs: "dracut -f"
     mdadm_conf: "/etc/mdadm.conf"
+
+- name: EL | Configure dracut to include mdadm.conf in initramfs
+  ansible.builtin.copy:
+    dest: /etc/dracut.conf.d/mdadm.conf
+    content: |
+      mdadmconf="yes"
+    mode: "0644"


### PR DESCRIPTION
Fixes #63.

## Root causes

Arrays were renamed `md127` after reboot on EL/Rocky hosts due to two separate bugs, both required fixing together.

**Root cause 1: initramfs rebuilt before mdadm.conf was written**

The `Arrays | Updating Initramfs` task previously ran immediately after array creation, before `mdadm.conf` had any ARRAY lines. The kernel booted from an initramfs with no array definitions and fell back to auto-assembling arrays with generic names (`md127`, etc.).

Fix: moved the initramfs rebuild to after the `Arrays | Updating mdadm conf for persistence` task so the ARRAY lines are present in `mdadm.conf` before dracut reads it.

**Root cause 2: dracut not configured to embed mdadm.conf**

On EL/Rocky 8/9, dracut only includes `mdadm.conf` content in the initramfs when `mdadmconf="yes"` is set in a dracut conf file. Without this, `dracut -f` rebuilds the initramfs but discards all array definitions regardless of ordering.

Fix: added a task to `tasks/el.yml` that writes `/etc/dracut.conf.d/mdadm.conf` with `mdadmconf="yes"` before any initramfs rebuild runs.

## Changes

- `tasks/el.yml`: add task to write `/etc/dracut.conf.d/mdadm.conf` configuring dracut to embed mdadm.conf
- `tasks/arrays.yml`: move `Arrays | Updating Initramfs` to after `Arrays | Updating mdadm conf for persistence`

## Test plan

- [ ] Create a RAID array on a Rocky 9 host with this role
- [ ] Verify `/etc/dracut.conf.d/mdadm.conf` contains `mdadmconf="yes"` after the play runs
- [ ] Verify `/etc/mdadm.conf` contains the ARRAY line before the initramfs rebuild fires
- [ ] Reboot and confirm the array retains its configured name (e.g. `md0`, not `md127`)
- [ ] Verify behaviour is unchanged on a Debian/Ubuntu host